### PR TITLE
Updating Sayathun's membershipType

### DIFF
--- a/contributors.ts
+++ b/contributors.ts
@@ -101,7 +101,7 @@ const contributors = [
   },
   {
     language: 'zh-CHS',
-    membershipType: 3,
+    membershipType: 2,
     membershipId: '4611686018455839117', // Sayathun
   },
 ];


### PR DESCRIPTION
hopefully changing it to 2 will allow his profile to be shown in the credits. since his main platform of choice is Playstation.